### PR TITLE
Streaming to Milk VR running on Gear VR

### DIFF
--- a/latex/chapters/problems-of-stitching/ab-testing.tex
+++ b/latex/chapters/problems-of-stitching/ab-testing.tex
@@ -62,7 +62,7 @@ Tap the touchpad of your Gear VR while pointing the gaze cursor on your video. T
 
 {\large Streaming to Milk VR on Gear VR. \par}
 
-Milk VR on Gear VR supports streaming your own files via HTTP. Start a Webserver (you probably already have one running on your NAS), create special "milkvr:" links (documented in the \textbf{\href{https://milkvr.com/#/content/faq}{Milk VR content FAQ}}) using \textbf{\href{https://github.com/abnormalend/milkvr-url-maker}{MilkVR URL Maker}} and store them in a HTML file. Browse to the file using a browser on the phone you use with Gear VR. It will start up Milk VR with the movie file indicated.
+Milk VR on Gear VR supports streaming your own files via HTTP. Start a Webserver (you probably already have one running on your NAS), create special "milkvr:" links (documented in the \textbf{\href{https://milkvr.com/#/content/faq}{Milk VR content FAQ}}) for example by using \textbf{\href{https://github.com/abnormalend/milkvr-url-maker}{MilkVR URL Maker}} and store them in a HTML file. Browse to the file using a browser on the phone you use with Gear VR. It will start up Milk VR with the movie file indicated.
 
 The Android app \textbf{\href{https://github.com/heavykick/MilkVRLauncher/releases}{MilkVRLauncher}} lets you create permanent linkFiles to movie files accessible via HTTP that will show up under "My Downloads" in Milk VR.
 

--- a/latex/chapters/problems-of-stitching/ab-testing.tex
+++ b/latex/chapters/problems-of-stitching/ab-testing.tex
@@ -60,5 +60,13 @@ Under ‘Apps’, launch the Oculus app and start the 360 Videos app. Put the he
 
 Tap the touchpad of your Gear VR while pointing the gaze cursor on your video. Then check for the seams that require your attention.
 
+{\large Streaming to Milk VR on Gear VR. \par}
+
+Milk VR on Gear VR supports streaming your own files via HTTP. Start a Webserver (you probably already have one running on your NAS), create special "milkvr:" links (documented in the \textbf{\href{https://milkvr.com/#/content/faq}{Milk VR content FAQ}}) using \textbf{\href{https://github.com/abnormalend/milkvr-url-maker}{MilkVR URL Maker}} and store them in a HTML file. Browse to the file using a browser on the phone you use with Gear VR. It will start up Milk VR with the movie file indicated.
+
+The Android app \textbf{\href{https://github.com/heavykick/MilkVRLauncher/releases}{MilkVRLauncher}} lets you create permanent linkFiles to movie files accessible via HTTP that will show up under "My Downloads" in Milk VR.
+
+Milk VR is currently only available from the US Oculus store. Use a US VPN to download it if you are located elsewhere.
+
 \clearpage
 \end{fullwidth}


### PR DESCRIPTION
If you have an HTTP server, you don't have to copy your movies to the phone used with Gear VR, you can stream them instead to the Milk VR app saving space and time.

Solves issue #200 